### PR TITLE
Support python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ benchmark
             self.size = 25000
 
         def test_pow_operator(self):
-            for i in xrange(self.size):
+            for i in range(self.size):
                 z = i**.5
 
         def test_pow_function(self):
-            for i in xrange(self.size):
+            for i in range(self.size):
                 z = pow(i, .5)
 
         def test_sqrt_function(self):
-            for i in xrange(self.size):
+            for i in range(self.size):
                 z = math.sqrt(i)
 
     class Benchmark_Sqrt2(Benchmark_Sqrt):

--- a/benchmark/Benchmark.py
+++ b/benchmark/Benchmark.py
@@ -144,20 +144,20 @@ class Benchmark(object):
     def __asMarkdown(self, header, table):
         maxSize = self.__columnWidths(header, table)
         lines = []
-        lines.append(' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(header)]))
+        lines.append(' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(header)]))
         lines.append('-|-'.join(['-'*size for size in maxSize]))
         for row in table:
-            lines.append(' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(row)]))
+            lines.append(' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(row)]))
         return os.linesep.join(lines)
 
     def __asRst(self, header, table):
         maxSize = self.__columnWidths(header, table)
         lines = []
         lines.append('+-' + '-+-'.join(['-'*size for size in maxSize]) + '-+')
-        lines.append('| ' + ' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(header)]) + ' |')
+        lines.append('| ' + ' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(header)]) + ' |')
         lines.append('+=' + '=+='.join(['='*size for size in maxSize]) + '=+')
         for row in table:
-            lines.append('| ' + ' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(row)]) + ' |')
+            lines.append('| ' + ' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(row)]) + ' |')
             lines.append('+-' + '-+-'.join(['-'*size for size in maxSize]) + '-+')
         return os.linesep.join(lines)
 

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -7,8 +7,8 @@ __maintainer__ = "Jeffrey R. Spies"
 __email__ = "jspies@gmail.com"
 __status__ = "Beta"
 
-from main import BenchmarkProgram, main
-from Benchmark import Benchmark
+from .main import BenchmarkProgram, main
+from .Benchmark import Benchmark
 
 
 

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -3,7 +3,7 @@
 # Website: http://jspi.es/benchmark
 
 from . import __VERSION__
-from Benchmark import Benchmark
+from .Benchmark import Benchmark
 
 import time
 import platform
@@ -13,7 +13,7 @@ import sys
 class BenchmarkProgram(object):
 
     def __init__(self, module="__main__", **kwargs):
-        if isinstance(module, basestring):
+        if isinstance(module, str):
             self.module = __import__(module)
 
         benchmarks = self.loadFromModule(self.module)

--- a/examples/benchmarkDictSorting.py
+++ b/examples/benchmarkDictSorting.py
@@ -21,28 +21,28 @@ class SortDictByValue(benchmark.Benchmark):
         random.shuffle(self.d)
     
     def test_pep265(self):
-        return sorted(self.d.iteritems(), key=itemgetter(1))
+        return sorted(self.d.items(), key=itemgetter(1))
     
     def test_stupid(self):
-        return [(k,v) for v,k in sorted([(v,k) for k,v in self.d.iteritems()])]
+        return [(k,v) for v,k in sorted([(v,k) for k,v in self.d.items()])]
     
     def test_listExpansion(self):
-        L = [(k,v) for (k,v) in self.d.iteritems()]
+        L = [(k,v) for (k,v) in self.d.items()]
         return sorted(L, key=lambda x: x[1])
     
     def test_generator(self):
-        L = ((k,v) for (k,v) in self.d.iteritems())
+        L = ((k,v) for (k,v) in self.d.items())
         return sorted(L, key=lambda x: x[1])
     
     def test_lambda(self):
-        return sorted(self.d.iteritems(), key=lambda x: x[1])
+        return sorted(self.d.items(), key=lambda x: x[1])
     
     def test_formalFnInner(self):
         def fninner(x):return x[1]
-        return sorted(self.d.iteritems(), key=fninner)
+        return sorted(self.d.items(), key=fninner)
     
     def test_formalFnOuter(self):
-        return sorted(self.d.iteritems(), key=fnouter)
+        return sorted(self.d.items(), key=fnouter)
 
 class SortLargerDictByValue(SortDictByValue):
     

--- a/examples/benchmarkGlobs.py
+++ b/examples/benchmarkGlobs.py
@@ -15,7 +15,7 @@ class BenchmarkGlobs(benchmark.Benchmark):
     
     def setUp(self):
         self.walk_root = tempfile.gettempdir()
-        for i in xrange(0, 100):
+        for i in range(0, 100):
             tempfile.mkstemp(suffix=".txt")
     
     def test_glob(self):


### PR DESCRIPTION
I execute 2to3, undo unnecessary list wrapping, replaced string module invocations with string object invocations

**Note**: `isinstance(module, basestring)` is now replaced with `isinstance(module, str)`. I don't think it's make sense to add dependency on six due to this issue because it's very unlikely that someone provided a unicode string as a 'module' argument and still uses python 2. I believe that it's also very unlikely that someone relies on a 'module' argument at all.
