### PR TITLE
Allow to store benchmarks in submodules

### DIFF
--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -9,12 +9,13 @@ import time
 import platform
 import os
 import sys
+import importlib
 
 class BenchmarkProgram(object):
 
     def __init__(self, module="__main__", **kwargs):
         if isinstance(module, str):
-            self.module = __import__(module)
+            self.module = importlib.import_module(module)
 
         benchmarks = self.loadFromModule(self.module)
 


### PR DESCRIPTION
From [python docs](https://docs.python.org/dev/library/importlib.html): 

> The most important difference between these two functions is that import_module() returns the specified package or module (e.g. pkg.mod), while **import**() returns the top-level package or module (e.g. pkg)

 is available in standard library since [3.1](https://docs.python.org/dev/library/importlib.html) and [2.7](https://docs.python.org/2/library/importlib.html)

e.g. this allows to run the following:

``` python
import benchmark

benchmark.main(module='nested.module.benchmarks')
```
